### PR TITLE
hotfix/multitenant-list: Making Bounty List Multitenant

### DIFF
--- a/src/app/commands/bounty/Bounty.ts
+++ b/src/app/commands/bounty/Bounty.ts
@@ -202,7 +202,7 @@ export default class Bounty extends SlashCommand {
 				command = DeleteBounty(guildMember, ctx.options.delete['bounty-id'], ctx.guildID);
 				break;
 			case 'list':
-				command = ListBounty(guildMember, ctx.options.list['list-type']);
+				command = ListBounty(guildMember, ctx.options.list['list-type'], ctx.guildID);
 				break;
 			case 'submit':
 				command = SubmitBounty(guildMember, ctx.options.submit['bounty-id'], 

--- a/src/app/service/bounty/ListBounty.ts
+++ b/src/app/service/bounty/ListBounty.ts
@@ -9,28 +9,28 @@ import MongoDbUtils from '../../utils/MongoDbUtils';
 
 const DB_RECORD_LIMIT = 10;
 
-export default async (guildMember: GuildMember, listType: string): Promise<any> => {
+export default async (guildMember: GuildMember, listType: string, guildID: string): Promise<any> => {
 	await BountyUtils.validateBountyType(guildMember, listType);
 
 	let dbRecords: Cursor;
 	const db: Db = await MongoDbUtils.connect(constants.DB_NAME_BOUNTY_BOARD);
-	const dbCollection = db.collection(constants.DB_COLLECTION_BOUNTIES);
+	const dbBounty = db.collection(constants.DB_COLLECTION_BOUNTIES);
 
 	switch (listType) {
 	case 'CREATED_BY_ME':
-		dbRecords = dbCollection.find({ 'createdBy.discordId': guildMember.user.id, status: { $ne: 'Deleted' } }).limit(DB_RECORD_LIMIT);
+		dbRecords = dbBounty.find({ 'createdBy.discordId': guildMember.user.id, status: { $ne: 'Deleted' }, 'customerId': guildID }).limit(DB_RECORD_LIMIT);
 		break;
 	case 'CLAIMED_BY_ME':
-		dbRecords = dbCollection.find({ 'claimedBy.discordId': guildMember.user.id, status: { $ne: 'Deleted' } }).limit(DB_RECORD_LIMIT);
+		dbRecords = dbBounty.find({ 'claimedBy.discordId': guildMember.user.id, status: { $ne: 'Deleted' }, 'customerId': guildID }).limit(DB_RECORD_LIMIT);
 		break;
 	case 'DRAFT_BY_ME':
-		dbRecords = dbCollection.find({ 'createdBy.discordId': guildMember.user.id, status: 'Draft' }).limit(DB_RECORD_LIMIT);
+		dbRecords = dbBounty.find({ 'createdBy.discordId': guildMember.user.id, status: 'Draft', 'customerId': guildID }).limit(DB_RECORD_LIMIT);
 		break;
 	case 'OPEN':
-		dbRecords = dbCollection.find({ status: 'Open' }).limit(DB_RECORD_LIMIT);
+		dbRecords = dbBounty.find({ status: 'Open', 'customerId': guildID }).limit(DB_RECORD_LIMIT);
 		break;
 	case 'IN_PROGRESS':
-		dbRecords = dbCollection.find({ status: 'In-Progress' }).limit(DB_RECORD_LIMIT);
+		dbRecords = dbBounty.find({ status: 'In-Progress', 'customerId': guildID }).limit(DB_RECORD_LIMIT);
 		break;
 	default:
 		Log.info('invalid list-type');


### PR DESCRIPTION
In `List` subcommand, updated mongo queries to only find bounties with the same `guildId` as the command context

Tested in BBBS and in a personal server